### PR TITLE
.gitignoreの変更と.env.exampleに必要な環境変数名を記述

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+API_END_POINT=
+X-API-KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env.local
 
 # vercel
 .vercel


### PR DESCRIPTION
.gitignoreの.env*のままだと.env.exampleがpushできないので.env.localにした
.env.exampleにはAPIのエンドポイントとそこにアクセするためのKeyの環境変数名を用意した