### PR TITLE
docs: 命名規則に設定オブジェクトは定数と同じパスカルケースではなくキャメルケースと明示的に書いた

### DIFF
--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -28,6 +28,13 @@
   - `function getUserInfo(userId, userName) { /* ... */ }`
   - `const handleClick = (event) => { /* ... */ };`
 
+## 設定オブジェクト
+
+- **規則**: キャメルケース
+- **例**:
+  - `const apiConf = { ... };`
+  - `const apiPath = { ... };`
+
 ## コンポーネント
 
 - **規則**: パスカルケース


### PR DESCRIPTION
定数全てをパスカルケースと書いていたけど設定オブジェクトはキャメルケースにした
例: apiConfやapiPathなど