### PR TITLE
jestを使ったgetPrefecturesの正常なテストケースと異常なテストケースを作った

### DIFF
--- a/src/__tests__/services/api/getPrefectures.ts
+++ b/src/__tests__/services/api/getPrefectures.ts
@@ -26,4 +26,20 @@ describe('getPrefectures', () => {
       },
     ]);
   });
+
+  // テストケース: レスポンスがOKでない場合
+  test('レスポンスがOKでない場合はfalseを返す', async (): Promise<void> => {
+    // モックのfetch関数を定義
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+
+    // getPrefectures関数を実行
+    const response: Prefecture[] | false = await getPrefectures();
+
+    // レスポンスがfalseであることを確認
+    expect(response).toBe(false);
+  });
 });

--- a/src/__tests__/services/api/getPrefectures.ts
+++ b/src/__tests__/services/api/getPrefectures.ts
@@ -57,4 +57,19 @@ describe('getPrefectures', () => {
     // レスポンスがfalseであることを確認
     expect(response).toBe(false);
   });
+
+  // テストケース: レスポンスデータが空の配列の場合
+  test('レスポンスデータが空の配列の場合はfalseを返す', async (): Promise<void> => {
+    // モックのfetch関数を定義
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async (): Promise<Prefecture[]> => [],
+    });
+
+    // getPrefectures関数を実行
+    const response: Prefecture[] | false = await getPrefectures();
+
+    // レスポンスがfalseであることを確認
+    expect(response).toBe(false);
+  });
 });

--- a/src/__tests__/services/api/getPrefectures.ts
+++ b/src/__tests__/services/api/getPrefectures.ts
@@ -84,4 +84,9 @@ describe('getPrefectures', () => {
     // レスポンスがfalseであることを確認
     expect(response).toBe(false);
   });
+
+  // テスト後にfetchをリセット
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 });

--- a/src/__tests__/services/api/getPrefectures.ts
+++ b/src/__tests__/services/api/getPrefectures.ts
@@ -42,4 +42,19 @@ describe('getPrefectures', () => {
     // レスポンスがfalseであることを確認
     expect(response).toBe(false);
   });
+
+  // テストケース: レスポンスデータが配列でない場合
+  test('レスポンスデータが配列でない場合はfalseを返す', async (): Promise<void> => {
+    // モックのfetch関数を定義
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async (): Promise<unknown> => ({ message: 'Invalid data' }),
+    });
+
+    // getPrefectures関数を実行
+    const response: Prefecture[] | false = await getPrefectures();
+
+    // レスポンスがfalseであることを確認
+    expect(response).toBe(false);
+  });
 });

--- a/src/__tests__/services/api/getPrefectures.ts
+++ b/src/__tests__/services/api/getPrefectures.ts
@@ -2,7 +2,9 @@ import getPrefectures from '@/services/api/getPrefectures';
 import { Prefecture } from '@/types/api/Prefecture';
 
 describe('getPrefectures', () => {
-  test('都道府県一覧を取得できる', async () => {
+  // テストケース: 正常系
+  test('都道府県一覧を取得できる', async (): Promise<void> => {
+    // モックのfetch関数を定義
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async (): Promise<Prefecture[]> => [
@@ -12,7 +14,11 @@ describe('getPrefectures', () => {
         },
       ],
     });
+
+    // getPrefectures関数を実行
     const response = await getPrefectures();
+
+    // fetchで取得したデータが正しいか確認
     expect(response).toEqual([
       {
         prefCode: 1,

--- a/src/__tests__/services/api/getPrefectures.ts
+++ b/src/__tests__/services/api/getPrefectures.ts
@@ -72,4 +72,16 @@ describe('getPrefectures', () => {
     // レスポンスがfalseであることを確認
     expect(response).toBe(false);
   });
+
+  // テストケース: エラーが発生した場合
+  test('エラーが発生した場合はfalseを返す', async (): Promise<void> => {
+    // モックのfetch関数を定義
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    // getPrefectures関数を実行
+    const response: Prefecture[] | false = await getPrefectures();
+
+    // レスポンスがfalseであることを確認
+    expect(response).toBe(false);
+  });
 });

--- a/src/__tests__/services/api/getPrefectures.ts
+++ b/src/__tests__/services/api/getPrefectures.ts
@@ -16,7 +16,7 @@ describe('getPrefectures', () => {
     });
 
     // getPrefectures関数を実行
-    const response = await getPrefectures();
+    const response: Prefecture[] | false = await getPrefectures();
 
     // fetchで取得したデータが正しいか確認
     expect(response).toEqual([

--- a/src/__tests__/services/api/getPrefectures.ts
+++ b/src/__tests__/services/api/getPrefectures.ts
@@ -1,0 +1,23 @@
+import getPrefectures from '@/services/api/getPrefectures';
+import { Prefecture } from '@/types/api/Prefecture';
+
+describe('getPrefectures', () => {
+  test('都道府県一覧を取得できる', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async (): Promise<Prefecture[]> => [
+        {
+          prefCode: 1,
+          prefName: '北海道',
+        },
+      ],
+    });
+    const response = await getPrefectures();
+    expect(response).toEqual([
+      {
+        prefCode: 1,
+        prefName: '北海道',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## 追加したテストケース
- 正常なテストケース
- レスポンスがOKでない場合
- レスポンスデータが配列でない場合
- レスポンスデータが空の配列の場合
- エラーが発生した場合