### PR TITLE
apiConfを分割代入に変更+dataの値が予期せぬ値だったので修正

### DIFF
--- a/src/services/api/getPrefectures.ts
+++ b/src/services/api/getPrefectures.ts
@@ -36,17 +36,17 @@ export default async function getPrefectures(): Promise<Prefecture[] | false> {
     }
 
     // レスポンスデータから都道府県一覧を取得
-    const data: Prefecture[] = await res.json().then((resData) => resData.result);
+    const { result }: { result: Prefecture[] } = await res.json();
     // console.log(data);
 
     // データが配列でなく、もしくは空の配列の場合はエラーを表示してfalseを返す
-    if (!Array.isArray(data) || data.length === 0) {
+    if (!Array.isArray(result) || result.length === 0) {
       console.error('No valid data or empty data');
       return false;
     }
 
     // データが取得できた場合はそのまま返す
-    return data;
+    return result;
   } catch (error: unknown) {
     if (error instanceof Error) {
       // エラーがError型の場合はエラーメッセージを表示

--- a/src/services/api/getPrefectures.ts
+++ b/src/services/api/getPrefectures.ts
@@ -35,7 +35,7 @@ export default async function getPrefectures(): Promise<Prefecture[] | false> {
       return false;
     }
 
-    // レスポンスの中にからjsonデータを取得
+    // レスポンスからjsonデータを取得
     const jsonData = await res.json();
 
     // jsonDataの中にresultがない場合はエラーを表示してfalseを返す

--- a/src/services/api/getPrefectures.ts
+++ b/src/services/api/getPrefectures.ts
@@ -10,8 +10,10 @@ import { Prefecture } from '@/types/api/Prefecture';
  */
 export default async function getPrefectures(): Promise<Prefecture[] | false> {
   try {
-    // APIの都道府県一覧から取得するURL
-    const url: string = `${apiConf.API_ENDPOINT}${apiPath.PREFECTURES}`;
+    // APIの設定を取得
+    const { API_ENDPOINT, X_API_KEY } = apiConf;
+    // 都道府県一覧を取得するURL
+    const url: string = `${API_ENDPOINT}${apiPath.PREFECTURES}`;
 
     // APIの都道府県一覧を取得する
     const res = await fetch(url, {
@@ -23,7 +25,7 @@ export default async function getPrefectures(): Promise<Prefecture[] | false> {
       headers: {
         'Content-Type': 'application/json',
         // X-API-KEYは環境変数から取得
-        'X-API-KEY': apiConf.X_API_KEY,
+        'X-API-KEY': X_API_KEY,
       },
     });
 

--- a/src/services/api/getPrefectures.ts
+++ b/src/services/api/getPrefectures.ts
@@ -35,18 +35,27 @@ export default async function getPrefectures(): Promise<Prefecture[] | false> {
       return false;
     }
 
-    // レスポンスデータから都道府県一覧を取得
-    const { result }: { result: Prefecture[] } = await res.json();
+    // レスポンスの中にからjsonデータを取得
+    const jsonData = await res.json();
+
+    // jsonDataの中にresultがない場合はエラーを表示してfalseを返す
+    if (!jsonData.result) {
+      console.error('No result in response');
+      return false;
+    }
+
+    // jsonDataの中にresultがある場合は、resultを取得
+    const data: Prefecture[] = jsonData.result;
     // console.log(data);
 
     // データが配列でなく、もしくは空の配列の場合はエラーを表示してfalseを返す
-    if (!Array.isArray(result) || result.length === 0) {
+    if (!Array.isArray(data) || data.length === 0) {
       console.error('No valid data or empty data');
       return false;
     }
 
     // データが取得できた場合はそのまま返す
-    return result;
+    return data;
   } catch (error: unknown) {
     if (error instanceof Error) {
       // エラーがError型の場合はエラーメッセージを表示

--- a/src/services/api/getPrefectures.ts
+++ b/src/services/api/getPrefectures.ts
@@ -35,8 +35,9 @@ export default async function getPrefectures(): Promise<Prefecture[] | false> {
       return false;
     }
 
-    // レスポンスデータからJSONを取得
-    const data: Prefecture[] = await res.json();
+    // レスポンスデータから都道府県一覧を取得
+    const data: Prefecture[] = await res.json().then((resData) => resData.result);
+    // console.log(data);
 
     // データが配列でなく、もしくは空の配列の場合はエラーを表示してfalseを返す
     if (!Array.isArray(data) || data.length === 0) {


### PR DESCRIPTION
### 変更点
- getPrefectures()のapiConfを分割代入を使ってAPI_ENDPOINTとX_API_KEYに分けた
- res.json()だと{ message:[], result: [欲しい値] }となっていて予期せぬ値だったためresultだけ抽出した

### 注意
- getPrefectures()の中を変更したため__tests__の一部のケースでfaildになることが予想される