### PR TITLE
都道府県一覧のデータは基本的に変わらないのでキャッシュを利用した方がいいので変更した

### DIFF
--- a/src/services/api/getPrefectures.ts
+++ b/src/services/api/getPrefectures.ts
@@ -19,8 +19,8 @@ export default async function getPrefectures(): Promise<Prefecture[] | false> {
     const res = await fetch(url, {
       // メソッドはGET
       method: 'GET',
-      // キャッシュはno-store
-      cache: 'no-store',
+      // 都道府県一覧は基本的に変わることがないのでキャッシュを使用
+      cache: 'force-cache',
       // リクエストヘッダーにContent-TypeとX-API-KEYを設定
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
### 変更点
- fetchオプションのcacheをno-storeからforce-cacheに変更した