### PR TITLE
feat: prefCodeを使って人口構成を取得できるAPI Routerを作った

### DIFF
--- a/src/app/api/v1/population/comp/[prefCode]/route.ts
+++ b/src/app/api/v1/population/comp/[prefCode]/route.ts
@@ -1,0 +1,64 @@
+import fetchPopulationCompByPrefCode from '@/services/api/populationComp/fetchPopulationCompByPrefCode';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest, { params }: { params: { prefCode: string } }) {
+  try {
+    // URLから文字列型のprefCodeを取得(await がないとエラーになる)
+    const { prefCode: prefCodeString } = await params;
+
+    // 文字列のprefCodeを数値に変換
+    const prefCode = Number(prefCodeString);
+    // NaNチェックを追加
+    if (isNaN(prefCode)) {
+      return NextResponse.json(
+        {
+          message: 'prefCode must be a valid number',
+        },
+        { status: 400 }
+      );
+    }
+
+    // prefCodeが0以下の場合はエラーを返す
+    if (prefCode <= 0) {
+      return NextResponse.json(
+        {
+          message: 'prefCode must be greater than 0',
+        },
+        { status: 400 }
+      );
+    }
+
+    // prefCodeが47より大きい場合はエラーを返す
+    if (prefCode > 47) {
+      return NextResponse.json(
+        {
+          message: 'prefCode must be less than or equal to 47',
+        },
+        { status: 400 }
+      );
+    }
+
+    // fetchPopulationCompByPrefCode関数を呼び出してprefCodeに対応する都道府県の人口構成を取得
+    const response = await fetchPopulationCompByPrefCode({ prefCode });
+
+    return NextResponse.json(response);
+  } catch (error) {
+    // エラーがErrorインスタンスの場合は、そのままエラーメッセージを返す
+    if (error instanceof Error) {
+      return NextResponse.json(
+        {
+          message: error.message,
+        },
+        { status: 500 }
+      );
+    }
+
+    // エラーがErrorインスタンスでない場合は、Unknown errorを返す
+    return NextResponse.json(
+      {
+        message: 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/population/comp/[prefCode]/route.ts
+++ b/src/app/api/v1/population/comp/[prefCode]/route.ts
@@ -12,9 +12,8 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest, { params }: { params: { prefCode: string } }) {
   try {
-    // URLから文字列型のprefCodeを取得(await がないとエラーになる)
-    const { prefCode: prefCodeString } = await params;
-
+    // URLから文字列型のprefCodeを取得
+    const { prefCode: prefCodeString } = params;
     // 文字列のprefCodeを数値に変換
     const prefCode = Math.trunc(Number(prefCodeString));
 

--- a/src/app/api/v1/population/comp/[prefCode]/route.ts
+++ b/src/app/api/v1/population/comp/[prefCode]/route.ts
@@ -16,7 +16,8 @@ export async function GET(request: NextRequest, { params }: { params: { prefCode
     const { prefCode: prefCodeString } = await params;
 
     // 文字列のprefCodeを数値に変換
-    const prefCode = Number(prefCodeString);
+    const prefCode = Math.trunc(Number(prefCodeString));
+
     // NaNチェックを追加
     if (isNaN(prefCode)) {
       return NextResponse.json(

--- a/src/app/api/v1/population/comp/[prefCode]/route.ts
+++ b/src/app/api/v1/population/comp/[prefCode]/route.ts
@@ -1,6 +1,15 @@
 import fetchPopulationCompByPrefCode from '@/services/api/populationComp/fetchPopulationCompByPrefCode';
 import { NextRequest, NextResponse } from 'next/server';
 
+/**
+ * @method GET
+ * @path /api/v1/population/comp/[prefCode]
+ * @return 都道府県の人口構成のAPIレスポンス
+ * @description 都道府県番号を使ってその都道府県の人口構成を取得するAPIのレスポンスを返す
+ *
+ * @author @kmjak
+ */
+
 export async function GET(request: NextRequest, { params }: { params: { prefCode: string } }) {
   try {
     // URLから文字列型のprefCodeを取得(await がないとエラーになる)

--- a/src/app/api/v1/population/comp/route.ts
+++ b/src/app/api/v1/population/comp/route.ts
@@ -2,18 +2,42 @@ import fetchPopulationCompByPrefCode from '@/services/api/populationComp/fetchPo
 import { NextRequest, NextResponse } from 'next/server';
 
 /**
- * @method GET
- * @path /api/v1/population/comp/[prefCode]
+ * @method POST
+ * @path /api/v1/population/comp/
  * @return 都道府県の人口構成のAPIレスポンス
  * @description 都道府県番号を使ってその都道府県の人口構成を取得するAPIのレスポンスを返す
  *
  * @author @kmjak
  */
 
-export async function GET(request: NextRequest, { params }: { params: { prefCode: string } }) {
+export async function POST(request: NextRequest) {
   try {
-    // URLから文字列型のprefCodeを取得
-    const { prefCode: prefCodeString } = params;
+    // リクエストボディを取得
+    const requestBody = await request.json();
+
+    // リクエストボディにprefCodeが含まれているか確認
+    if (!('prefCode' in requestBody)) {
+      return NextResponse.json(
+        {
+          message: 'prefCode is required',
+        },
+        { status: 400 }
+      );
+    }
+
+    // リクエストボディからprefCodeを取得
+    const prefCodeString = requestBody.prefCode;
+
+    // prefCodeがundefinedの場合はエラーを返す
+    if (prefCodeString === undefined) {
+      return NextResponse.json(
+        {
+          message: 'prefCode is required',
+        },
+        { status: 400 }
+      );
+    }
+
     // 文字列のprefCodeを数値に変換
     const prefCode = Math.trunc(Number(prefCodeString));
 


### PR DESCRIPTION
### 内容
- /api/v1/population/comp/[prefCode]にGET通信を送るとprefCodeの人口構成をfetchすることができる
- prefCodeは数値のみで1以上47以下である必要がある
- 小数点は切り捨てられる
- fetch中にエラーが起きたら500番のエラーを返す