### PR TITLE
test: fetchPrefectures関数の戻り値にfalseをつけていたので削除

### DIFF
--- a/src/__tests__/services/api/prefecture/fetchPrefectures.test.ts
+++ b/src/__tests__/services/api/prefecture/fetchPrefectures.test.ts
@@ -54,7 +54,7 @@ describe('fetchPrefectures', () => {
     });
 
     // fetchPrefectures関数を実行
-    const response: Prefecture[] | false = await fetchPrefectures();
+    const response: Prefecture[] = await fetchPrefectures();
 
     // fetchPrefectures関数の期待する戻り値と一致するか確認
     expect(response).toEqual([


### PR DESCRIPTION
### 変更内容
- テストケースないでfetchPrefecturesの戻り値をPrefecture[]とfalseを想定していたのでfalseを消した