### PR TITLE
refactor: apiConfやapiPathの環境変数がちゃんと読めていなかったらエラーを投げる設定にした+ドキュメントを他のと統一した

### DIFF
--- a/src/services/api/populationComp/fetchPopulationCompByPrefCode.ts
+++ b/src/services/api/populationComp/fetchPopulationCompByPrefCode.ts
@@ -22,8 +22,26 @@ export default async function fetchPopulationCompByPrefCode({
     // APIの設定を取得
     const { API_ENDPOINT, X_API_KEY }: ApiConf = apiConf;
 
+    // API_ENDPOINTが空の場合はエラーを投げる
+    if (API_ENDPOINT === '') {
+      throw new Error('API_ENDPOINT is empty');
+    }
+
+    // X_API_KEYが空の場合はエラーを投げる
+    if (X_API_KEY === '') {
+      throw new Error('X_API_KEY is empty');
+    }
+
+    // APIのパスを取得
+    const { POPULATION_COMP: POPULATION_COMP_PATH } = apiPath;
+
+    // POPULATION_COMP_PATHが空の場合はエラーを投げる
+    if (POPULATION_COMP_PATH === '') {
+      throw new Error('POPULATION_COMP is empty');
+    }
+
     // 人口構成を取得するURL
-    const apiUrl: string = `${API_ENDPOINT}${apiPath.POPULATION_COMP}?prefCode=${prefCode}`;
+    const apiUrl: string = `${API_ENDPOINT}${POPULATION_COMP_PATH}?prefCode=${prefCode}`;
 
     // 指定した都道府県の人口構成を取得する
     const response = await fetch(apiUrl, {

--- a/src/services/api/populationComp/fetchPopulationCompByPrefCode.ts
+++ b/src/services/api/populationComp/fetchPopulationCompByPrefCode.ts
@@ -6,7 +6,9 @@ import { ApiConf } from '@/types/api/conf/ApiConf';
 import { PopulationCompResponse } from '@/types/api/models/populationComp/PopulationCompResponse';
 
 /**
- * 指定した都道府県の人口構成を取得する関数
+ * @file fetchPopulationCompByPrefCode.ts
+ * @exports fetchPopulationCompByPrefCode
+ * @description 指定した都道府県の人口構成を取得する関数
  * @param prefCode 都道府県コード
  * @return 人口構成のデータ
  *


### PR DESCRIPTION
### 変更内容
- apiConf(API_ENDPOINTとX_API_KEY)やapiPath(POPULATION_COMP_PATH)がうまく読み込まれていなかったらエラーを投げるようにした
- 他のドキュメントの書き方と統一した