### PR TITLE
feat: 都道府県一覧をAPI Routerから取得するgetPrefectures関数を作った

### DIFF
--- a/src/usecases/api/prefecture/getPrefectures.ts
+++ b/src/usecases/api/prefecture/getPrefectures.ts
@@ -20,11 +20,11 @@ export default async function getPrefectures(): Promise<Prefecture[]> {
       throw new Error('HOST_URL is not defined');
     }
 
-    // APIのURLを作成
-    const apiUr: string = `${HOST_URL}/api/v1/prefecture/list`;
+    // API RouterのURLを作成
+    const apiRooterUrl: string = `${HOST_URL}/api/v1/prefecture/list`;
 
     // APIの都道府県一覧を取得する
-    const response = await fetch(apiUr, {
+    const response = await fetch(apiRooterUrl, {
       // メソッドはGET
       method: 'GET',
 

--- a/src/usecases/api/prefecture/getPrefectures.ts
+++ b/src/usecases/api/prefecture/getPrefectures.ts
@@ -21,10 +21,10 @@ export default async function getPrefectures(): Promise<Prefecture[]> {
     }
 
     // API RouterのURLを作成
-    const apiRooterUrl: string = `${HOST_URL}/api/v1/prefecture/list`;
+    const apiRouterUrl: string = `${HOST_URL}/api/v1/prefecture/list`;
 
     // APIの都道府県一覧を取得する
-    const response = await fetch(apiRooterUrl, {
+    const response = await fetch(apiRouterUrl, {
       // メソッドはGET
       method: 'GET',
 

--- a/src/usecases/api/prefecture/getPrefectures.ts
+++ b/src/usecases/api/prefecture/getPrefectures.ts
@@ -15,7 +15,7 @@ export default async function getPrefectures(): Promise<Prefecture[]> {
     // HOST_URLを取得
     const { HOST_URL } = envConf;
 
-    // HOST_URLがよ読めていない場合はエラーを投げる
+    // HOST_URLが読み込めていない場合はエラーを投げる
     if (HOST_URL === '') {
       throw new Error('HOST_URL is not defined');
     }

--- a/src/usecases/api/prefecture/getPrefectures.ts
+++ b/src/usecases/api/prefecture/getPrefectures.ts
@@ -1,0 +1,54 @@
+import { envConf } from '@/conf/env/envConf';
+import { Prefecture } from '@/types/api/models/prefecture/Prefecture';
+
+/**
+ * @file getPrefectures.ts
+ * @exports getPrefectures
+ * @description 都道府県の情報を取得する関数
+ * @return 都道府県一覧
+ *
+ * @author @kmjak
+ */
+
+export default async function getPrefectures(): Promise<Prefecture[]> {
+  try {
+    // HOST_URLを取得
+    const { HOST_URL } = envConf;
+
+    // HOST_URLがよ読めていない場合はエラーを投げる
+    if (HOST_URL === '') {
+      throw new Error('HOST_URL is not defined');
+    }
+
+    // APIのURLを作成
+    const apiUr: string = `${HOST_URL}/api/v1/prefecture/list`;
+
+    // APIの都道府県一覧を取得する
+    const response = await fetch(apiUr, {
+      // メソッドはGET
+      method: 'GET',
+
+      // 都道府県一覧は基本的に変わることがないのでキャッシュを使用
+      cache: 'force-cache',
+    });
+
+    // レスポンスがOKでない場合はエラーを投げる
+    if (!response.ok) {
+      throw new Error('Failed to fetch prefectures');
+    }
+
+    // レスポンスをJSON形式で取得
+    const responseJson: Prefecture[] = await response.json();
+
+    // レスポンスのデータを返す
+    return responseJson;
+  } catch (error) {
+    if (error instanceof Error) {
+      // エラーがErrorインスタンスの場合は、そのままエラーメッセージを返す
+      throw error;
+    } else {
+      // エラーがErrorインスタンスでない場合は、Unknown errorを返す
+      throw new Error('Unknown error');
+    }
+  }
+}


### PR DESCRIPTION
### 内容
- envConfのHOST_URLが空の時、つまり読み込めていない時エラーを投げる
- apiRouterUrlを使ってAPI Routerから都道府県一覧を取得
- データを取得した時responseがokではないときエラーを投げる
- 正常にデータを取得できたらそのデータを返す