### PR TITLE
feat: 都道府県番号をもとに人口構成を取得するusecaseを作った

### DIFF
--- a/src/usecases/api/populationComp/getPopulationCompByPrefCode.ts
+++ b/src/usecases/api/populationComp/getPopulationCompByPrefCode.ts
@@ -1,3 +1,6 @@
+import { envConf } from '@/conf/env/envConf';
+import { PopulationCompResponse } from '@/types/api/models/populationComp/PopulationCompResponse';
+
 /**
  * @file getPopulationCompByPrefCode.ts
  * @exports getPopulationCompByPrefCode
@@ -7,9 +10,6 @@
  *
  * @author @kmjak
  */
-
-import { envConf } from '@/conf/env/envConf';
-import { PopulationCompResponse } from '@/types/api/models/populationComp/PopulationCompResponse';
 
 export default async function getPopulationCompByPrefCode({ prefCode }: { prefCode: number }) {
   // HOST_URLを取得

--- a/src/usecases/api/populationComp/getPopulationCompByPrefCode.ts
+++ b/src/usecases/api/populationComp/getPopulationCompByPrefCode.ts
@@ -1,0 +1,53 @@
+/**
+ * @file getPopulationCompByPrefCode.ts
+ * @exports getPopulationCompByPrefCode
+ * @description 都道府県コードを指定して、人口構成の情報を取得する関数
+ * @param prefCode 都道府県コード
+ * @return 都道府県の人口構成情報
+ *
+ * @author @kmjak
+ */
+
+import { envConf } from '@/conf/env/envConf';
+import { PopulationCompResponse } from '@/types/api/models/populationComp/PopulationCompResponse';
+
+export default async function getPopulationCompByPrefCode({ prefCode }: { prefCode: number }) {
+  // HOST_URLを取得
+  const { HOST_URL } = envConf;
+
+  // HOST_URLが読み込めていない場合はエラーを投げる
+  if (HOST_URL === '') {
+    throw new Error('HOST_URL is not defined');
+  }
+
+  // API RouterのURLを作成
+  const apiRouterUrl: string = `${HOST_URL}/api/v1/population/comp`;
+
+  // APIの都道府県コードを指定して人口構成を取得する
+  const response = await fetch(apiRouterUrl, {
+    // メソッドはPOST
+    method: 'POST',
+
+    // ヘッダーを指定
+    headers: {
+      'Content-Type': 'application/json',
+    },
+
+    // リクエストボディを指定
+    body: JSON.stringify({ prefCode }),
+
+    // 都道府県コードは基本的に変わることがないのでキャッシュを使用
+    cache: 'force-cache',
+  });
+
+  // レスポンスがOKでない場合はエラーを投げる
+  if (!response.ok) {
+    throw new Error('Failed to fetch population composition');
+  }
+
+  // レスポンスをJSON形式で取得
+  const responseJson: PopulationCompResponse = await response.json();
+
+  // レスポンスのデータを返す
+  return responseJson;
+}


### PR DESCRIPTION
### 内容
- /api/v1/population/comp/にPOST通信でprefCodeを送るとその都道府県の人口構成を取得する
- envConfのHOST_URLが空の場合エラーを投げる
- API Routerからデータをfetchするときにresponse.okがtrueじゃない場合エラーを投げる