### PR TITLE
refactor: 人口構成を取得するusecasesの戻り値の型定義を厳密にした

### DIFF
--- a/src/hooks/api/usePopulationComp.ts
+++ b/src/hooks/api/usePopulationComp.ts
@@ -1,0 +1,7 @@
+/**
+ * @file usePopulationComp.ts
+ * @description 人口構成に関するhandlerをまとめたカスタムフック
+ * @returns
+ *
+ * @author @kmjak
+ */

--- a/src/usecases/api/populationComp/getPopulationCompByPrefCode.ts
+++ b/src/usecases/api/populationComp/getPopulationCompByPrefCode.ts
@@ -11,7 +11,11 @@ import { PopulationCompResponse } from '@/types/api/models/populationComp/Popula
  * @author @kmjak
  */
 
-export default async function getPopulationCompByPrefCode({ prefCode }: { prefCode: number }) {
+export default async function getPopulationCompByPrefCode({
+  prefCode,
+}: {
+  prefCode: number;
+}): Promise<PopulationCompResponse> {
   try {
     // HOST_URLを取得
     const { HOST_URL } = envConf;


### PR DESCRIPTION
### 変更内容
- getPopulationCompByPrefCodeのPromsie<>を書いていなかったので戻り値の型を厳密にした

### 注意事項
- usePopulationComp.tsの作成途中の内容を間違えて一緒にpushしてしまった