### PR TITLE
refactor: __tests__/usecasesのリファクタリング

### DIFF
--- a/src/__tests__/usecases/populationComp/getPopulationCompByPrefCode.test.ts
+++ b/src/__tests__/usecases/populationComp/getPopulationCompByPrefCode.test.ts
@@ -1,9 +1,10 @@
+import { PopulationCompResponse } from '@/types/models/populationComp/PopulationCompResponse';
 import getPopulationCompByPrefCode from '@/usecases/populationComp/getPopulationCompByPrefCode';
 
 /**
  * @file getPopulationCompByPrefCode.test.ts
  * @description getPopulationCompByPrefCode関数のテスト
- * @see src/usecases/api/populationComp/getPopulationCompByPrefCode.ts
+ * @see src/usecases/populationComp/getPopulationCompByPrefCode.ts
  *
  * @author @kmjak
  */
@@ -12,7 +13,6 @@ import getPopulationCompByPrefCode from '@/usecases/populationComp/getPopulation
  * envConfのモック
  * HOST_URLをモックする
  * @see src/conf/env/envConf.ts
- *
  */
 jest.mock('@/conf/env/envConf', () => ({
   envConf: {
@@ -89,10 +89,10 @@ describe('getPopulationCompByPrefCode', () => {
     });
 
     // テスト対象の関数を実行
-    const result = await getPopulationCompByPrefCode({ prefCode: 1 });
+    const response: PopulationCompResponse = await getPopulationCompByPrefCode({ prefCode: 1 });
 
     // 結果の検証
-    expect(result).toEqual({
+    expect(response).toEqual({
       boundaryYear: 2020,
       data: [
         {

--- a/src/__tests__/usecases/prefecture/getPrefectures.test.ts
+++ b/src/__tests__/usecases/prefecture/getPrefectures.test.ts
@@ -4,7 +4,7 @@ import getPrefectures from '@/usecases/prefecture/getPrefectures';
 /**
  * @file getPrefectures.test.ts
  * @description getPrefecture関数のテスト
- * @see src/usecases/api/prefecture/getPrefectures.ts
+ * @see src/usecases/prefecture/getPrefectures.ts
  *
  * @author @kmjak
  */
@@ -13,7 +13,6 @@ import getPrefectures from '@/usecases/prefecture/getPrefectures';
  * envConfのモック
  * HOST_URLをモックする
  * @see src/conf/env/envConf.ts
- *
  */
 jest.mock('@/conf/env/envConf', () => ({
   envConf: {


### PR DESCRIPTION
### 変更内容
- @see のパスに無駄にapiとついてるところがあったので修正
- 人口構成を取得するusecasesのテストコードでresultとしていた場所を他のファイルと統一するためにresponseに変更
- responseに静的型付けを行った