### PR TITLE
refactor: 不要なドキュメントの削除

### DIFF
--- a/src/__tests__/services/populationComp/fetchPopulationCompByPrefCode.test.ts
+++ b/src/__tests__/services/populationComp/fetchPopulationCompByPrefCode.test.ts
@@ -4,6 +4,7 @@ import { PopulationCompResponse } from '@/types/models/populationComp/Population
 /**
  * @file fetchPopulationCompByPrefCode.test.ts
  * @description fetchPopulationCompByPrefCode関数のテスト
+ * @see src/services/populationComp/fetchPopulationCompByPrefCode.ts
  *
  * @author @kmjak
  */
@@ -11,7 +12,7 @@ import { PopulationCompResponse } from '@/types/models/populationComp/Population
 /**
  * apiConfのモック
  * APIのエンドポイントとAPIキーをモックする
- * @see src/conf/api/apiConf.ts
+ * @see src/conf/apiConf.ts
  */
 jest.mock('@/conf/api/apiConf', () => ({
   apiConf: {
@@ -23,7 +24,7 @@ jest.mock('@/conf/api/apiConf', () => ({
 /**
  * apiPathのモック
  * 人口構成を取得するAPIのパスをモックする
- * @see src/conf/api/apiPath.ts
+ * @see src/conf/apiPath.ts
  */
 jest.mock('@/conf/api/apiPath', () => ({
   apiPath: {
@@ -56,7 +57,7 @@ describe('fetchPopulationCompByPrefCode', () => {
    * 都道府県コードを指定して人口構成を取得できる
    *
    * @expect
-   * result : {
+   * {
    *   boundaryYear: 2020,
    *   data: [
    *     {
@@ -205,7 +206,7 @@ describe('fetchPopulationCompByPrefCode', () => {
    * テストケース: レスポンスデータにresultがない場合
    *
    * @expect
-   *
+   * No result in response
    */
   test('レスポンスデータにresultがない場合「No result in response」とエラーを投げる', async (): Promise<void> => {
     // モックのfetch関数を定義

--- a/src/__tests__/services/prefecture/fetchPrefectures.test.ts
+++ b/src/__tests__/services/prefecture/fetchPrefectures.test.ts
@@ -4,6 +4,7 @@ import { Prefecture } from '@/types/models/prefecture/Prefecture';
 /**
  * @file fetchPrefectures.test.ts
  * @description fetchPrefectures関数のテスト
+ * @see src/services/prefecture/fetchPrefectures.ts
  *
  * @author @kmjak
  */
@@ -11,7 +12,7 @@ import { Prefecture } from '@/types/models/prefecture/Prefecture';
 /**
  * apiConfのモック
  * APIのエンドポイントとAPIキーをモックする
- * @see src/conf/api/apiConf.ts
+ * @see src/conf/apiConf.ts
  */
 jest.mock('@/conf/api/apiConf', () => ({
   apiConf: {
@@ -23,7 +24,7 @@ jest.mock('@/conf/api/apiConf', () => ({
 /**
  * apiPathのモック
  * 都道府県一覧を取得するAPIのパスをモックする
- * @see src/conf/api/apiPath.ts
+ * @see src/conf/apiPath.ts
  */
 jest.mock('@/conf/api/apiPath', () => ({
   apiPath: {
@@ -31,12 +32,6 @@ jest.mock('@/conf/api/apiPath', () => ({
   },
 }));
 
-/**
- * テストケース: fetchPrefectures
- * 都道府県一覧を取得する関数のテスト
- *
- * @author @kmjak
- */
 describe('fetchPrefectures', () => {
   // 元のfetchを保存する変数
   let originalFetch: typeof global.fetch;
@@ -62,7 +57,7 @@ describe('fetchPrefectures', () => {
    * 都道府県一覧を取得できる
    *
    * @expect
-   * result : [
+   * [
    *   {
    *     prefCode: 1,
    *     prefName: '北海道',


### PR DESCRIPTION
### 変更内容
- @ seeのパスに無駄なapiが入っていたので削除
- 二回ドキュメントを書いている場所の修正
- 都道府県一覧を取得するservicesの正常なテストケースに置いて@ expectに不要なresult: がついていたので削除