### PR TITLE
test: usePopulationCompのテストコードを作った

### DIFF
--- a/src/__tests__/hooks/populationComp/README.md
+++ b/src/__tests__/hooks/populationComp/README.md
@@ -1,0 +1,1 @@
+populationComp に関する hooks のテストコードを格納するディレクトリ

--- a/src/__tests__/hooks/populationComp/usePopulationComp.test.ts
+++ b/src/__tests__/hooks/populationComp/usePopulationComp.test.ts
@@ -1,0 +1,98 @@
+import { renderHook, act } from '@testing-library/react';
+import usePopulationComp from '@/hooks/populationComp/usePopulationComp';
+import { PopulationCompResponse } from '@/types/models/populationComp/PopulationCompResponse';
+import getPopulationCompByPrefCode from '@/usecases/populationComp/getPopulationCompByPrefCode';
+
+jest.mock('@/usecases/populationComp/getPopulationCompByPrefCode');
+const mockedGetPopulationCompByPrefCode = getPopulationCompByPrefCode as jest.Mock;
+
+// モックデータ
+const populationCompResponse: PopulationCompResponse = {
+  boundaryYear: 2020,
+  data: [
+    {
+      label: '総人口',
+      data: [
+        { year: 1980, value: 100000 },
+        { year: 1990, value: 110000 },
+      ],
+    },
+    {
+      label: '年少人口',
+      data: [
+        { year: 1980, value: 20000 },
+        { year: 1990, value: 22000 },
+      ],
+    },
+    {
+      label: '生産年齢人口',
+      data: [
+        { year: 1980, value: 60000 },
+        { year: 1990, value: 66000 },
+      ],
+    },
+    {
+      label: '老年人口',
+      data: [
+        { year: 1980, value: 20000 },
+        { year: 1990, value: 22000 },
+      ],
+    },
+  ],
+};
+/**
+ * @file usePopulationComp.test.ts
+ * @description usePopulationCompのテスト
+ * @see src/hooks/populationComp/usePopulationComp.ts
+ *
+ * @author @kmjak
+ */
+describe('usePrefecture', () => {
+  /**
+   * テストケース: handleGetPopulationCompByPrefCodeで人口構成データを取得できることを確認する
+   *
+   * @expect
+   * populationComp: PopulationCompResponse
+   */
+  it('handleGetPopulationCompByPrefCodeからデータが取得できているか', async () => {
+    mockedGetPopulationCompByPrefCode.mockResolvedValue(populationCompResponse);
+    const { result } = renderHook(() => usePopulationComp());
+    await act(async () => {
+      const populationComp: PopulationCompResponse | undefined =
+        await result.current.handleGetPopulationCompByPrefCode({ prefCode: 1 });
+      expect(populationComp).toEqual(populationCompResponse);
+    });
+  });
+
+  /**
+   * テストケース: handleGetPopulationCompByPrefCodeで不正な都道府県コードを渡すとundefinedが返ることを確認する
+   *
+   * @expect
+   * populationComp: undefined
+   */
+  it('handleGetPopulationCompByPrefCodeからundefinedが返る', async () => {
+    mockedGetPopulationCompByPrefCode.mockResolvedValue(undefined);
+    const { result } = renderHook(() => usePopulationComp());
+    await act(async () => {
+      const populationComp: PopulationCompResponse | undefined =
+        await result.current.handleGetPopulationCompByPrefCode({ prefCode: -1 });
+      expect(populationComp).toBeUndefined();
+    });
+  });
+
+  /**
+   * テストケース: handleGetPopulationCompByPrefCodeでエラーが発生した場合、undefinedが返ることを確認する
+   *
+   * @expect
+   * populationComp: undefined
+   */
+  it('handleGetPopulationCompByPrefCodeからundefinedが返る', async () => {
+    mockedGetPopulationCompByPrefCode.mockRejectedValue(new Error('Error'));
+    const { result } = renderHook(() => usePopulationComp());
+    await act(async () => {
+      const populationComp: PopulationCompResponse | undefined =
+        await result.current.handleGetPopulationCompByPrefCode({ prefCode: 1 });
+      expect(populationComp).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
### 内容
- READMEファイルの作成
- src/__tests__/hooks/populationComp/usePopulationComp.test.tsの作成
---
### テストケース
- handleGetPopulationCompByPrefCodeで人口構成データを取得できることを確認する
- handleGetPopulationCompByPrefCodeで不正な都道府県コードを渡すとundefinedが返ることを確認する
- handleGetPopulationCompByPrefCodeでエラーが発生した場合、undefinedが返ることを確認する