### PR TITLE
feat: hooksなどを使用して、Appsyncからデータの取得や更新、リアルタイム通信を実現

### DIFF
--- a/src/components/chart/Chart.tsx
+++ b/src/components/chart/Chart.tsx
@@ -108,7 +108,7 @@ export default function Chart({ chartMode, prefectures }: ChartProps): JSX.Eleme
         // actionがdeleteAllの場合は、全ての都道府県コードを指定してpopulationByPrefCodeとboundaryYearsから削除
         setPopulationByPrefCode({});
         setBoundaryYears({});
-      } else if (action == 'insertList') {
+      } else if (action === 'insertList') {
         // actionがinsertListの場合は、都道府県コードを指定してpopulationByPrefCodeとboundaryYearsに追加
 
         // prefCodesがundefinedの場合は何もしない

--- a/src/components/chart/Chart.tsx
+++ b/src/components/chart/Chart.tsx
@@ -48,7 +48,7 @@ export default function Chart({ chartMode, prefectures }: ChartProps): JSX.Eleme
       if (prefectureSelectionAction === undefined) return;
 
       // prefectureSelectionActionからactionとprefCodeを取得
-      const { action, prefCode } = prefectureSelectionAction;
+      const { action, prefCode, prefCodes } = prefectureSelectionAction;
 
       // actionがundefinedの場合は何もしない
       if (action === undefined) return;
@@ -108,6 +108,45 @@ export default function Chart({ chartMode, prefectures }: ChartProps): JSX.Eleme
         // actionがdeleteAllの場合は、全ての都道府県コードを指定してpopulationByPrefCodeとboundaryYearsから削除
         setPopulationByPrefCode({});
         setBoundaryYears({});
+      } else if (action == 'insertList') {
+        // actionがinsertListの場合は、都道府県コードを指定してpopulationByPrefCodeとboundaryYearsに追加
+
+        // prefCodesがundefinedの場合は何もしない
+        if (prefCodes === undefined) return;
+
+        // populationByPrefCodeとboundaryYearsをPrefCodesの数だけ取得
+        await Promise.all(
+          prefCodes.map(async (prefCode) => {
+            // actionがinsertListの場合は、都道府県コードを指定して人口構成データを取得
+            const populationCompResponse: PopulationCompResponse | undefined =
+              await handleGetPopulationCompByPrefCode({
+                prefCode,
+              });
+
+            // populationCompResponseがundefinedの場合は何もしない
+            if (populationCompResponse === undefined) return;
+
+            // populationCompResponseからboundaryYearとpopulationCompを取得
+            const { boundaryYear, data: populationCompData } = populationCompResponse;
+
+            // boundaryYearとpopulationCompが存在する場合は、都道府県コードを指定してpopulationByPrefCodeとboundaryYearsに追加
+            if (boundaryYear && populationCompData) {
+              // boundaryYearsにboundaryYearを追加
+              setBoundaryYears((prev) => ({ ...prev, [prefCode]: boundaryYear }));
+
+              // populationByPrefCodeにラベルごとの人口構成データを追加
+              setPopulationByPrefCode((prev) => ({
+                ...prev,
+                [prefCode]: {
+                  total: populationCompData[0].data,
+                  young: populationCompData[1].data,
+                  working: populationCompData[2].data,
+                  elderly: populationCompData[3].data,
+                },
+              }));
+            }
+          })
+        );
       }
     };
 

--- a/src/components/prefectureSelector/PrefectureSelector.tsx
+++ b/src/components/prefectureSelector/PrefectureSelector.tsx
@@ -33,7 +33,7 @@ export default function PrefectureSelector({ prefectures }: PrefectureSelectorPr
   const client = generateClient();
   const { checkedPrefectures, handleTogglePrefCode, handleDeselectAll, handleSetPrefCodes } =
     usePrefecture();
-  const { handleUpdatePrefCodes, handleGetPrefCodes } = useAppsync();
+  const { handleUpdatePrefCodes, handleGetPrefCodes, handleResetPrefCodes } = useAppsync();
   const setPrefectureSelectionAction = useSetAtom(prefectureSelectionActionAtom);
 
   /**
@@ -80,6 +80,14 @@ export default function PrefectureSelector({ prefectures }: PrefectureSelectorPr
     setPrefectureSelectionAction({
       action: 'deleteAll',
     });
+
+    // Appsyncのデータも更新する
+    const isReset = handleResetPrefCodes({
+      roomId, // TODO: roomIdを引数で受け取るようにする
+    });
+    if (!isReset) {
+      alert('都道府県コードのリセットに失敗しました');
+    }
   };
 
   useEffect(() => {

--- a/src/components/prefectureSelector/PrefectureSelector.tsx
+++ b/src/components/prefectureSelector/PrefectureSelector.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Prefecture } from '@/types/models/prefecture/Prefecture';
-import { JSX } from 'react';
+import { JSX, useEffect } from 'react';
 import SearchPrefectureForm from './SearchPrefectureForm';
 import PrefectureCheckboxList from './PrefectureCheckboxList';
 import usePrefecture from '@/hooks/prefecture/usePrefecture';
@@ -27,8 +27,9 @@ interface PrefectureSelectorProps {
  * @author @kmjak
  */
 export default function PrefectureSelector({ prefectures }: PrefectureSelectorProps): JSX.Element {
-  const { checkedPrefectures, handleTogglePrefCode, handleDeselectAll } = usePrefecture();
-  const { handleUpdatePrefCodes } = useAppsync();
+  const { checkedPrefectures, handleTogglePrefCode, handleDeselectAll, handleSetPrefCodes } =
+    usePrefecture();
+  const { handleUpdatePrefCodes, handleGetPrefCodes } = useAppsync();
   const setPrefectureSelectionAction = useSetAtom(prefectureSelectionActionAtom);
 
   /**
@@ -76,6 +77,21 @@ export default function PrefectureSelector({ prefectures }: PrefectureSelectorPr
       action: 'deleteAll',
     });
   };
+
+  useEffect(() => {
+    // Appsyncのデータを取得する
+    const fetchPrefCodes = async () => {
+      console.log('Appsyncからデータを取得');
+      const prefCodes = await handleGetPrefCodes({ roomId: 'kmjak' }); // TODO: roomIdを引数で受け取るようにする
+      handleSetPrefCodes({ prefCodes });
+    };
+
+    fetchPrefCodes();
+    return () => {
+      // コンポーネントがアンマウントされたときに、チェックボックスの状態をリセットする
+      handleDeselectAll();
+    };
+  }, []);
 
   return (
     <section className="flex flex-col gap-3 sm:gap-3 md:gap-4 lg:gap-6 w-full">

--- a/src/components/prefectureSelector/PrefectureSelector.tsx
+++ b/src/components/prefectureSelector/PrefectureSelector.tsx
@@ -27,6 +27,7 @@ interface PrefectureSelectorProps {
  * @author @kmjak
  */
 export default function PrefectureSelector({ prefectures }: PrefectureSelectorProps): JSX.Element {
+  const roomId = 'kmjak'; // TODO: roomIdを引数で受け取るようにする
   const { checkedPrefectures, handleTogglePrefCode, handleDeselectAll, handleSetPrefCodes } =
     usePrefecture();
   const { handleUpdatePrefCodes, handleGetPrefCodes } = useAppsync();
@@ -43,7 +44,7 @@ export default function PrefectureSelector({ prefectures }: PrefectureSelectorPr
 
     // Appsyncのデータも更新する
     const isAppsyncUpdated = await handleUpdatePrefCodes({
-      roomId: 'kmjak', // TODO: roomIdを引数で受け取るようにする
+      roomId, // TODO: roomIdを引数で受け取るようにする
       prefCode,
       checkedPrefectures,
     });
@@ -81,9 +82,12 @@ export default function PrefectureSelector({ prefectures }: PrefectureSelectorPr
   useEffect(() => {
     // Appsyncのデータを取得する
     const fetchPrefCodes = async () => {
-      console.log('Appsyncからデータを取得');
-      const prefCodes = await handleGetPrefCodes({ roomId: 'kmjak' }); // TODO: roomIdを引数で受け取るようにする
+      const prefCodes = await handleGetPrefCodes({ roomId }); // TODO: roomIdを引数で受け取るようにする
       handleSetPrefCodes({ prefCodes });
+      setPrefectureSelectionAction({
+        action: 'insertList',
+        prefCodes,
+      });
     };
 
     fetchPrefCodes();
@@ -91,7 +95,7 @@ export default function PrefectureSelector({ prefectures }: PrefectureSelectorPr
       // コンポーネントがアンマウントされたときに、チェックボックスの状態をリセットする
       handleDeselectAll();
     };
-  }, []);
+  }, [roomId]);
 
   return (
     <section className="flex flex-col gap-3 sm:gap-3 md:gap-4 lg:gap-6 w-full">

--- a/src/components/prefectureSelector/PrefectureSelector.tsx
+++ b/src/components/prefectureSelector/PrefectureSelector.tsx
@@ -75,14 +75,14 @@ export default function PrefectureSelector({ prefectures }: PrefectureSelectorPr
    * @description 全てのチェックボックスの状態を外す処理
    * @returns {void}
    */
-  const handleDeselectAllPrefCodes = (): void => {
+  const handleDeselectAllPrefCodes = async (): Promise<void> => {
     handleDeselectAll();
     setPrefectureSelectionAction({
       action: 'deleteAll',
     });
 
     // Appsyncのデータも更新する
-    const isReset = handleResetPrefCodes({
+    const isReset = await handleResetPrefCodes({
       roomId, // TODO: roomIdを引数で受け取るようにする
     });
     if (!isReset) {

--- a/src/hooks/graphql/useAppsync.ts
+++ b/src/hooks/graphql/useAppsync.ts
@@ -2,6 +2,7 @@
 
 import createRoom from '@/usecases/graphql/createRoom';
 import getPrefCodes from '@/usecases/graphql/getPrefCodes';
+import resetPrefCodes from '@/usecases/graphql/reestPrefCodes';
 import updatePrefCodes from '@/usecases/graphql/updatePrefCodes';
 
 /**
@@ -21,6 +22,7 @@ interface UseAppsyncReturns {
     prefCode: number;
     checkedPrefectures: number[];
   }) => Promise<boolean>;
+  handleResetPrefCodes: ({ roomId }: { roomId: string }) => Promise<boolean>;
   handleGetPrefCodes: ({ roomId }: { roomId: string }) => Promise<number[]>;
 }
 
@@ -30,6 +32,7 @@ interface UseAppsyncReturns {
  * @returns {
  *  handleCreateRoom: ({roomId}: {roomId:string}) => Promise<boolean>;
  *  handleUpdatePrefCodes: ({roomId, prefCode, checkedPrefectures}: {roomId:string; prefCode:number; checkedPrefectures:number[]}) => Promise<boolean>;
+ *  handleResetPrefCodes: ({roomId}: {roomId:string}) => Promise<boolean>;
  *  handleGetPrefCodes: ({roomId}: {roomId:string}) => Promise<number[]>;
  * }
  *
@@ -81,6 +84,23 @@ export default function useAppsync(): UseAppsyncReturns {
   };
 
   /**
+   * @description roomの都道府県番号をリセットする関数
+   * @param {string} roomId - 部屋のID
+   * @returns {Promise<boolean>} - 成功した場合はtrue、失敗した場合はfalse
+   */
+  const handleResetPrefCodes = async ({ roomId }: { roomId: string }): Promise<boolean> => {
+    try {
+      // roomIdをもとに都道府県コードをリセット
+      const isReset = await resetPrefCodes({ roomId });
+      if (!isReset) return false;
+      return true;
+    } catch {
+      // エラーが発生した場合はfalseを返す
+      return false;
+    }
+  };
+
+  /**
    * @description roomの都道府県番号を取得する関数
    * @param {string}
    * @returns {Promise<number[]>} - 都道府県コードの配列
@@ -101,6 +121,7 @@ export default function useAppsync(): UseAppsyncReturns {
   return {
     handleCreateRoom,
     handleUpdatePrefCodes,
+    handleResetPrefCodes,
     handleGetPrefCodes,
   };
 }

--- a/src/hooks/prefecture/usePrefecture.ts
+++ b/src/hooks/prefecture/usePrefecture.ts
@@ -10,6 +10,7 @@ import { useState } from 'react';
  *  checkedPrefectures: number[],
  *  handleTogglePrefCode: ({ prefCode }: { prefCode: number }) => void,
  *  handleDeselectAll: () => void
+ *  handleSetPrefCodes: ({ prefCodes }: { prefCodes: number[] }) => void
  * }
  *
  * @author @kmjak
@@ -19,6 +20,7 @@ export default function usePrefecture(): {
   checkedPrefectures: number[];
   handleTogglePrefCode: ({ prefCode }: { prefCode: number }) => boolean;
   handleDeselectAll: () => void;
+  handleSetPrefCodes: ({ prefCodes }: { prefCodes: number[] }) => void;
 } {
   const [checkedPrefectures, setCheckedPrefectures] = useState<number[]>([]);
 
@@ -45,5 +47,9 @@ export default function usePrefecture(): {
     setCheckedPrefectures([]);
   };
 
-  return { checkedPrefectures, handleTogglePrefCode, handleDeselectAll };
+  const handleSetPrefCodes = ({ prefCodes }: { prefCodes: number[] }): void => {
+    setCheckedPrefectures(prefCodes);
+  };
+
+  return { checkedPrefectures, handleTogglePrefCode, handleDeselectAll, handleSetPrefCodes };
 }

--- a/src/types/models/prefectureSelection/PrefectureSelectionAction.ts
+++ b/src/types/models/prefectureSelection/PrefectureSelectionAction.ts
@@ -7,6 +7,7 @@
  */
 
 export interface PrefectureSelectionAction {
-  action: 'insert' | 'delete' | 'deleteAll';
+  action: 'insert' | 'delete' | 'deleteAll' | 'insertList';
   prefCode?: number;
+  prefCodes?: number[];
 }

--- a/src/usecases/graphql/reestPrefCodes.ts
+++ b/src/usecases/graphql/reestPrefCodes.ts
@@ -1,0 +1,29 @@
+import { updateYumemiCodingTest202504 } from '@/graphql/mutations';
+import { generateClient } from 'aws-amplify/api';
+
+export default async function resetPrefCodes({ roomId }: { roomId: string }): Promise<boolean> {
+  const client = generateClient();
+
+  try {
+    const response = await client.graphql({
+      query: updateYumemiCodingTest202504,
+      variables: {
+        input: {
+          roomId,
+          prefCodes: [],
+        },
+      },
+    });
+
+    if (response.errors) {
+      throw new Error('部屋の都道府県コードのリセットに失敗しました');
+    }
+    return true;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    } else {
+      throw new Error('Unknown error');
+    }
+  }
+}


### PR DESCRIPTION
### 内容
- prefectureSelectionActionAtomの型に'insertList'とprefCodes?を追加
- handlePrefectureSelectionにAppsyncの更新処理を追加
- usePrefectureのhandleSetPrefCodesで渡されたprefCodesをそのままsetCheckedPrefecturesにセット
- 初回レンダリング時にAppsyncからデータを取得する処理を作った
- 初回レンダリング時に取得したprefCodesをもとにデータをセットする処理を追加
- subscriptionでリアルタイム通信を実現した