### PR TITLE
style: layout.tsxでバックグランドとデフォルトのtextの色を指定+グラフのheightの最小値を400pxに変更

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,7 +47,11 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <ConfigureAmplifyClientSide amplifyConf={amplifyConf} />
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-900 text-white`}
+      >
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/chart/ChartRender.tsx
+++ b/src/components/chart/ChartRender.tsx
@@ -56,7 +56,7 @@ export default function ChartRender({
   }
 
   return (
-    <div className="max-w-5xl h-[300px] sm:h-[350px] md:h-[400px] lg:h-[500px] border border-gray-300 rounded-lg shadow-md p-2 md:p-4 mx-auto">
+    <div className="max-w-5xl h-[400px] lg:h-[500px] border border-gray-300 rounded-lg shadow-md p-2 md:p-4 mx-auto">
       <Line data={chartData} options={chartOptions} />
     </div>
   );


### PR DESCRIPTION
### 内容
- layout.tsxでbackgroundとtextの色を指定した
- ChartRender.tsxでチャートの最小のheightを300pxから400pxに変更