### PR TITLE
test: describeとit('')の中が抽象的な書き方だったり、そもそも間違った内容が入っていたので修正

### DIFF
--- a/src/__tests__/hooks/populationComp/usePopulationComp.test.ts
+++ b/src/__tests__/hooks/populationComp/usePopulationComp.test.ts
@@ -65,12 +65,12 @@ describe('usePopulationComp', () => {
   });
 
   /**
-   * テストケース: handleGetPopulationCompByPrefCodeで不正な都道府県コードを渡すとundefinedが返ることを確認する
+   * テストケース: prefCodeが不正な値の場合undefinedが返ることを確認する
    *
    * @expect
    * populationComp: undefined
    */
-  it('handleGetPopulationCompByPrefCodeからundefinedが返る', async () => {
+  it('prefCodeが不正な値の場合undefinedが返る', async () => {
     mockedGetPopulationCompByPrefCode.mockResolvedValue(undefined);
     const { result } = renderHook(() => usePopulationComp());
     await act(async () => {
@@ -86,7 +86,7 @@ describe('usePopulationComp', () => {
    * @expect
    * populationComp: undefined
    */
-  it('handleGetPopulationCompByPrefCodeからundefinedが返る', async () => {
+  it('handleGetPopulationCompByPrefCodeでエラーが発生した場合、undefinedが返る', async () => {
     mockedGetPopulationCompByPrefCode.mockRejectedValue(new Error('Error'));
     const { result } = renderHook(() => usePopulationComp());
     await act(async () => {

--- a/src/__tests__/hooks/populationComp/usePopulationComp.test.ts
+++ b/src/__tests__/hooks/populationComp/usePopulationComp.test.ts
@@ -47,7 +47,7 @@ const populationCompResponse: PopulationCompResponse = {
  *
  * @author @kmjak
  */
-describe('usePrefecture', () => {
+describe('usePopulationComp', () => {
   /**
    * テストケース: handleGetPopulationCompByPrefCodeで人口構成データを取得できることを確認する
    *


### PR DESCRIPTION
### 内容
- usePopulationComp.test.tsのテストコードの修正
- describeでusePrefectureと書いていたのでusePopulationCompに変更
- it('')の中が重複していたので、より詳細に書いた