### PR TITLE
fix: prefectureSelectionActionのactionがinsertListの時、populationByPrefCodeとboudanryYearsを{}で初期化させる

### DIFF
--- a/src/components/chart/Chart.tsx
+++ b/src/components/chart/Chart.tsx
@@ -112,6 +112,8 @@ export default function Chart({ chartMode, prefectures }: ChartProps): JSX.Eleme
       } else if (action === 'insertList') {
         // actionがinsertListの場合は、都道府県コードを指定してpopulationByPrefCodeとboundaryYearsに追加
 
+        setPopulationByPrefCode({});
+        setBoundaryYears({});
         // prefCodesがundefinedの場合は何もしない
         if (prefCodes === undefined) return;
 


### PR DESCRIPTION
内容
- prefectureSelectionActionのactionがinsertListの時、populationByPrefCodeとboudanryYearsを{}で初期化することで、handleDeselectAllPrefCodesを押した時に全ユーザーのチェックボックスを初期化するようにした