### PR TITLE
fix: prefectureSelectionActionのactionがinsertListの時、populationByPrefCodeとboudanryYearsを{}で初期化させる

### DIFF
--- a/src/components/chart/Chart.tsx
+++ b/src/components/chart/Chart.tsx
@@ -110,7 +110,7 @@ export default function Chart({ chartMode, prefectures }: ChartProps): JSX.Eleme
         setPopulationByPrefCode({});
         setBoundaryYears({});
       } else if (action === 'insertList') {
-        // actionがinsertListの場合は、都道府県コードを指定してpopulationByPrefCodeとboundaryYearsに追加
+        // actionがinsertListの場合は、都道府県コードを指定してpopulationByPrefCodeとboundaryYearsをリセットしてから新しいデータを追加
 
         setPopulationByPrefCode({});
         setBoundaryYears({});


### PR DESCRIPTION
### 内容
- handleDeselectAllPrefCodesを押してリセットする時他のユーザーのデータもリセットするようにした