### PR TITLE
fix: undefined以外に配列の中身が0の時もpopulationByPrefCodeとboundaryYearsを空にする

### DIFF
--- a/src/components/chart/Chart.tsx
+++ b/src/components/chart/Chart.tsx
@@ -110,8 +110,8 @@ export default function Chart({ chartMode, prefectures }: ChartProps): JSX.Eleme
         setPopulationByPrefCode({});
         setBoundaryYears({});
       } else if (action === 'insertList') {
-        // prefCodesがundefinedの場合はpopulationByPrefCodeとboundaryYearsを空にする
-        if (prefCodes === undefined) {
+        // prefCodesがundefinedのまたはlengthが0場合はpopulationByPrefCodeとboundaryYearsを空にする
+        if (prefCodes === undefined || prefCodes.length === 0) {
           setPopulationByPrefCode({});
           setBoundaryYears({});
           return;


### PR DESCRIPTION
### 内容
- undefined以外に配列の中身が0の時もpopulationByPrefCodeとboundaryYearsを空にする